### PR TITLE
make parcel-related packages peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,5 +36,10 @@
     "http-proxy-middleware": "^2.0.6",
     "lodash.merge": "^4.6.2",
     "lodash.some": "^4.6.0"
+  },
+  "peerDependencies": {
+    "@mischnic/parcel-resolver-root": "*",
+    "@parcel/core": "*",
+    "@parcel/config-default": "*"
   }
 }


### PR DESCRIPTION
Thanks for this wonderful plugin, it very neatly integrates parcel into my static website workflow!

I found that I had some problems and weird errors regarding parcel versions when trying to customize my parcel behavior (with .parcelrc and other plugins). It seems the plugin works better if it declares parcel and parcel-related packages as peer dependencies, in order to make sure that the host package's parcel requirements (and version constraints) are used.

I'm not sure I understand node's peerDependencies very well, so please double-check this makes sense.